### PR TITLE
Potential fix for code scanning alert no. 4: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "qrcode": "^1.5.3",
     "sharp": "^0.32.6",
     "speakeasy": "^2.0.0",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const rateLimit = require('express-rate-limit');
 const session = require('express-session');
 const path = require('path');
 require('dotenv').config();
-
+const csrf = require('lusca').csrf;
 const app = express();
 const PORT = process.env.PORT || 9640;
 
@@ -68,6 +68,8 @@ app.use(session({
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
+// CSRF protection middleware
+app.use(csrf());
 // Static file serving for uploads with security headers
 app.use('/images', (req, res, next) => {
   // Add security headers for image serving


### PR DESCRIPTION
Potential fix for [https://github.com/josephclaytonhansen/josephhansen-dev-api/security/code-scanning/4](https://github.com/josephclaytonhansen/josephhansen-dev-api/security/code-scanning/4)

The best way to fix this vulnerability is to introduce a proper CSRF protection middleware early in the middleware chain, after session and body parsing are set up. The recommended package in the prompt is `lusca.csrf`. Add `const csrf = require('lusca').csrf;` to the imports, and `app.use(csrf());` after session and body parsing middlewares (immediately after line 65 or after lines 69). This ensures all incoming POST/PUT/PATCH/DELETE requests are protected by the standard token check. No existing functionality needs to change, only middleware addition (and possibly a new import).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
