### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/routes/images.js
+++ b/routes/images.js
@@ -276,8 +276,12 @@ router.post('/:id/resize', requireAuth, require2FA, async (req, res) => {
 
     const filepath = path.join(uploadDir, matchingFile);
     const allowedFormats = ['jpeg', 'png', 'webp'];
-    const selectedFormat = allowedFormats.includes(format.toLowerCase()) ? format.toLowerCase() : 'png';
-    const extension = selectedFormat === 'jpeg' ? 'jpg' : selectedFormat;
+    const sanitizedFormat = typeof format === 'string' && allowedFormats.includes(format.toLowerCase())
+      ? format.toLowerCase()
+      : 'png';
+    // Strict mapping: don't accept extension from user input
+    const extMap = { jpeg: 'jpg', png: 'png', webp: 'webp' };
+    const extension = extMap[sanitizedFormat];
     const newFilename = `${uuidv4()}.${extension}`;
     const newFilepath = path.join(uploadDir, newFilename);
 


### PR DESCRIPTION
Potential fix for [https://github.com/josephclaytonhansen/josephhansen-dev-api/security/code-scanning/3](https://github.com/josephclaytonhansen/josephhansen-dev-api/security/code-scanning/3)

To fully prevent users from influencing file paths, do the following:

- **Strictly validate the `format` field:** Ensure it only accepts fully controlled, hard-coded values.
- **Construct all file names from safe, UUID-based names, and controlled extensions.** Never allow user-supplied data to affect the generated filenames or extensions.
- **(Optional defense-in-depth):** After building the full path, resolve and check that it lies inside the intended upload directory.

In concrete terms for the code:
- On or before line 279, tightly validate the `format` using an explicit allow-list before using it, and default to 'png' if missing or invalid.
- Prevent accepting extensions of any kind from user input, and strictly join only server-generated filenames to the trusted upload directory.
- Ensure the extension is chosen from a safe mapping, not user input.

No new imports or libraries are needed, only a minor code change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
